### PR TITLE
move reward schedule to vector

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -102,6 +102,14 @@ public:
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPreBlossomPowTargetSpacing = 45;
         consensus.nPostBlossomPowTargetSpacing = 45;
+        // 174720 blocks/quarter
+        consensus.rewardSteps = {
+          {int64_t(174720 * 2), 15},
+          {int64_t(174720 * 3), 5},
+          {int64_t(174720 * 4), 5},
+          {int64_t(174720 * 5), 5},
+          {int64_t(174720 * 6), 5}
+        };
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = boost::none;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight =
@@ -237,6 +245,11 @@ public:
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPreBlossomPowTargetSpacing = 45;
         consensus.nPostBlossomPowTargetSpacing = 45;
+        consensus.rewardSteps = {
+          {int64_t(1600), 5},
+          {int64_t(1700), 5},
+          {int64_t(1800), 5}
+        };
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = 299187;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight =
@@ -361,6 +374,14 @@ public:
         consensus.nPowMaxAdjustUp = 0; // Turn off adjustment up
         consensus.nPreBlossomPowTargetSpacing = 45;
         consensus.nPostBlossomPowTargetSpacing = 45;
+        consensus.rewardSteps = {
+          {int64_t(1600), 5},
+          {int64_t(1700), 5},
+          {int64_t(1800), 5}
+        };
+        consensus.rewardSteps.emplace_back(int64_t(1600), 5);
+        consensus.rewardSteps.emplace_back(int64_t(1700), 5);
+        consensus.rewardSteps.emplace_back(int64_t(1800), 5);
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = 0;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight =

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -61,6 +61,14 @@ struct NetworkUpgrade {
     static constexpr int NO_ACTIVATION_HEIGHT = -1;
 };
 
+struct RewardStep {
+  // height where reward stepdown will occur
+  int64_t nHeight;
+  // number of whole arw that the reward should be reduced by
+  int nReduction;
+  RewardStep(int64_t h, int r) : nHeight(h), nReduction(r) {}
+};
+
 /** ZIP208 block target interval in seconds. */
 static const unsigned int PRE_BLOSSOM_POW_TARGET_SPACING = 150;
 static const unsigned int POST_BLOSSOM_POW_TARGET_SPACING = 75;
@@ -125,6 +133,7 @@ struct Params {
     int64_t nPowMaxAdjustUp;
     int64_t nPreBlossomPowTargetSpacing;
     int64_t nPostBlossomPowTargetSpacing;
+    std::vector<RewardStep> rewardSteps;
 
     int64_t PoWTargetSpacing(int nHeight) const;
     int64_t AveragingWindowTimespan(int nHeight) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1803,26 +1803,11 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
   // 91 days/quarter
   // 174720 blocks/quarter
 
-  // if (nHeight > 174720) {
-  //   nSubsidy -= 5 * COIN;
-  // }
-  if (nHeight > 174720 * 2) {
-    nSubsidy -= 5 * COIN;
-  }
-  if (nHeight > 174720 * 3) {
-    nSubsidy -= 5 * COIN;
-  }
-  if (nHeight > 174720 * 4) {
-    nSubsidy -= 5 * COIN;
-  }
-  if (nHeight > 174720 * 5) {
-    nSubsidy -= 5 * COIN;
-  }
-  if (nHeight > 174720 * 6) {
-    nSubsidy -= 5 * COIN;
-  }
-  if (nHeight > 174720 * 7) {
-    nSubsidy -= 5 * COIN;
+  int steps = consensusParams.rewardSteps.size();
+  for (int i = 0; i < steps; i++) {
+    if (nHeight >= consensusParams.rewardSteps[i].nHeight) {
+      nSubsidy -= consensusParams.rewardSteps[i].nReduction * COIN;
+    }
   }
 
   // Subsidy is cut in half every 2,803,200 blocks which will occur


### PR DESCRIPTION
- moves reward step down schedule to vector of structs so mainnet & testnet can be different
