### PR TITLE
Delete, Consolidate, Compact, Witness rework.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -225,6 +225,7 @@ BITCOIN_CORE_H = \
   wallet/asyncrpcoperation_common.h \
   wallet/asyncrpcoperation_mergetoaddress.h \
   wallet/asyncrpcoperation_saplingmigration.h \
+	wallet/asyncrpcoperation_saplingconsolidation.h \
   wallet/asyncrpcoperation_sendmany.h \
   wallet/asyncrpcoperation_shieldcoinbase.h \
   wallet/crypter.h \
@@ -316,6 +317,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/asyncrpcoperation_common.cpp \
   wallet/asyncrpcoperation_mergetoaddress.cpp \
   wallet/asyncrpcoperation_saplingmigration.cpp \
+	wallet/asyncrpcoperation_saplingconsolidation.cpp \
   wallet/asyncrpcoperation_sendmany.cpp \
   wallet/asyncrpcoperation_shieldcoinbase.cpp \
   wallet/crypter.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -408,6 +408,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), 100));
     strUsage += HelpMessageOpt("-migration", _("Enable the Sprout to Sapling migration"));
     strUsage += HelpMessageOpt("-migrationdestaddress=<zaddr>", _("Set the Sapling migration address"));
+    strUsage += HelpMessageOpt("-deletetx", _("Enable Old Transaction Deletion"));
+    strUsage += HelpMessageOpt("-deleteinterval", strprintf(_("Delete transaction every <n> blocks during inital block download (default: %i)"), DEFAULT_TX_DELETE_INTERVAL));
+    strUsage += HelpMessageOpt("-keeptxnum", strprintf(_("Keep the last <n> transactions (default: %i)"), DEFAULT_TX_RETENTION_LASTTX));
+    strUsage += HelpMessageOpt("-keeptxfornblocks", strprintf(_("Keep transactions for at least <n> blocks (default: %i)"), DEFAULT_TX_RETENTION_BLOCKS));
     if (showDebug)
         strUsage += HelpMessageOpt("-mintxfee=<amt>", strprintf("Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)",
             CURRENCY_UNIT, FormatMoney(CWallet::minTxFee.GetFeePerK())));
@@ -1705,6 +1709,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         // Set sapling migration status
         pwalletMain->fSaplingMigrationEnabled = GetBoolArg("-migration", false);
 
+        //Set Transaction Deletion Options
+        fTxDeleteEnabled = GetBoolArg("-deletetx", false);
+        fDeleteInterval = GetArg("-deleteinterval", DEFAULT_TX_DELETE_INTERVAL);
+        fKeepLastNTransactions = GetArg("-keeptxnum", DEFAULT_TX_RETENTION_LASTTX);
+        fDeleteTransactionsAfterNBlocks = GetArg("-keeptxfornblocks", DEFAULT_TX_RETENTION_BLOCKS);
+
         if (fFirstRun)
         {
             // Create new keyUser and set as default key
@@ -1903,6 +1913,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (pwalletMain) {
         // Add wallet transactions that aren't already in a block to mapTransactions
         pwalletMain->ReacceptWalletTransactions();
+
+        if (fTxDeleteEnabled) {
+          //Run Transaction Deleted
+          pwalletMain->DeleteWalletTransactions(chainActive.Tip(), true);
+        }
 
         // Run a thread to flush wallet periodically
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,6 +40,7 @@
 #include "key_io.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
+#include "wallet/asyncrpcoperation_saplingconsolidation.h"
 #endif
 #include <stdint.h>
 #include <stdio.h>
@@ -408,6 +409,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), 100));
     strUsage += HelpMessageOpt("-migration", _("Enable the Sprout to Sapling migration"));
     strUsage += HelpMessageOpt("-migrationdestaddress=<zaddr>", _("Set the Sapling migration address"));
+    strUsage += HelpMessageOpt("-consolidation", _("Enable auto Sapling note consolidation"));
+    strUsage += HelpMessageOpt("-consolidationtxfee", strprintf(_("Fee amount in Satoshis used send consolidation transactions. (default %i)"), DEFAULT_CONSOLIDATION_FEE));
     strUsage += HelpMessageOpt("-deletetx", _("Enable Old Transaction Deletion"));
     strUsage += HelpMessageOpt("-deleteinterval", strprintf(_("Delete transaction every <n> blocks during inital block download (default: %i)"), DEFAULT_TX_DELETE_INTERVAL));
     strUsage += HelpMessageOpt("-keeptxnum", strprintf(_("Keep the last <n> transactions (default: %i)"), DEFAULT_TX_RETENTION_LASTTX));
@@ -1708,6 +1711,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         // Set sapling migration status
         pwalletMain->fSaplingMigrationEnabled = GetBoolArg("-migration", false);
+
+        //Set Sapling Consolidation
+        pwalletMain->fSaplingConsolidationEnabled = GetBoolArg("-consolidation", false);
+        fConsolidationTxFee  = GetArg("-consolidationtxfee", DEFAULT_CONSOLIDATION_FEE);
 
         //Set Transaction Deletion Options
         fTxDeleteEnabled = GetBoolArg("-deletetx", false);

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.cpp
@@ -1,0 +1,202 @@
+#include "assert.h"
+#include "boost/variant/static_visitor.hpp"
+#include "asyncrpcoperation_saplingconsolidation.h"
+#include "init.h"
+#include "key_io.h"
+#include "rpc/protocol.h"
+#include "random.h"
+#include "sync.h"
+#include "tinyformat.h"
+#include "transaction_builder.h"
+#include "util.h"
+#include "utilmoneystr.h"
+#include "wallet.h"
+
+CAmount fConsolidationTxFee = DEFAULT_CONSOLIDATION_FEE;
+const int CONSOLIDATION_EXPIRY_DELTA = 100;
+
+
+AsyncRPCOperation_saplingconsolidation::AsyncRPCOperation_saplingconsolidation(int targetHeight) : targetHeight_(targetHeight) {}
+
+AsyncRPCOperation_saplingconsolidation::~AsyncRPCOperation_saplingconsolidation() {}
+
+void AsyncRPCOperation_saplingconsolidation::main() {
+    if (isCancelled())
+        return;
+
+    set_state(OperationStatus::EXECUTING);
+    start_execution_clock();
+
+    bool success = false;
+
+    try {
+        success = main_impl();
+    } catch (const UniValue& objError) {
+        int code = find_value(objError, "code").get_int();
+        std::string message = find_value(objError, "message").get_str();
+        set_error_code(code);
+        set_error_message(message);
+    } catch (const runtime_error& e) {
+        set_error_code(-1);
+        set_error_message("runtime error: " + string(e.what()));
+    } catch (const logic_error& e) {
+        set_error_code(-1);
+        set_error_message("logic error: " + string(e.what()));
+    } catch (const exception& e) {
+        set_error_code(-1);
+        set_error_message("general exception: " + string(e.what()));
+    } catch (...) {
+        set_error_code(-2);
+        set_error_message("unknown error");
+    }
+
+    stop_execution_clock();
+
+    if (success) {
+        set_state(OperationStatus::SUCCESS);
+    } else {
+        set_state(OperationStatus::FAILED);
+    }
+
+    std::string s = strprintf("%s: Sapling Consolidation transaction created. (status=%s", getId(), getStateAsString());
+    if (success) {
+        s += strprintf(", success)\n");
+    } else {
+        s += strprintf(", error=%s)\n", getErrorMessage());
+    }
+
+    LogPrintf("%s", s);
+}
+
+bool AsyncRPCOperation_saplingconsolidation::main_impl() {
+    LogPrint("zrpcunsafe", "%s: Beginning AsyncRPCOperation_saplingconsolidation.\n", getId());
+    auto consensusParams = Params().GetConsensus();
+    auto nextActivationHeight = NextActivationHeight(targetHeight_, consensusParams);
+    if (nextActivationHeight && targetHeight_ + CONSOLIDATION_EXPIRY_DELTA >= nextActivationHeight.get()) {
+        LogPrint("zrpcunsafe", "%s: Consolidation txs would be created before a NU activation but may expire after. Skipping this round.\n", getId());
+        setConsolidationResult(0, 0, std::vector<std::string>());
+        return true;
+    }
+
+    std::vector<SproutNoteEntry> sproutEntries;
+    std::vector<SaplingNoteEntry> saplingEntries;
+    std::set<libzcash::SaplingPaymentAddress> addresses;
+    {
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        // We set minDepth to 11 to avoid unconfirmed notes and in anticipation of specifying
+        // an anchor at height N-10 for each Sprout JoinSplit description
+        // Consider, should notes be sorted?
+        pwalletMain->GetFilteredNotes(sproutEntries, saplingEntries, "", 11);
+        pwalletMain->GetSaplingPaymentAddresses(addresses);
+    }
+
+    int numTxCreated = 0;
+    std::vector<std::string> consolidationTxIds;
+    CAmount amountConsolidated = 0;
+    CCoinsViewCache coinsView(pcoinsTip);
+
+    for (auto addr : addresses) {
+        libzcash::SaplingExtendedSpendingKey extsk;
+        if (pwalletMain->GetSaplingExtendedSpendingKey(addr, extsk)) {
+
+            std::vector<SaplingNoteEntry> fromNotes;
+            CAmount amountToSend = 0;
+            int maxQuantity = rand() % 35 + 10;
+            for (const SaplingNoteEntry& saplingEntry : saplingEntries) {
+
+                libzcash::SaplingIncomingViewingKey ivk;
+                pwalletMain->GetSaplingIncomingViewingKey(boost::get<libzcash::SaplingPaymentAddress>(saplingEntry.address), ivk);
+
+                //Select Notes from that same address we will be sending to.
+                if (ivk == extsk.expsk.full_viewing_key().in_viewing_key()) {
+                  amountToSend += CAmount(saplingEntry.note.value());
+                  fromNotes.push_back(saplingEntry);
+                }
+
+                //Only use a randomly determined number of notes between 10 and 45
+                if (fromNotes.size() >= maxQuantity)
+                  break;
+
+            }
+
+            //random minimum 2 - 12 required
+            int minQuantity = rand() % 10 + 2;
+            if (fromNotes.size() < minQuantity)
+              continue;
+
+            amountConsolidated += amountToSend;
+            auto builder = TransactionBuilder(consensusParams, targetHeight_, pwalletMain, pzcashParams, &coinsView, &cs_main);
+            builder.SetExpiryHeight(targetHeight_ + CONSOLIDATION_EXPIRY_DELTA);
+            LogPrint("zrpcunsafe", "%s: Beginning creating transaction with Sapling output amount=%s\n", getId(), FormatMoney(amountToSend - fConsolidationTxFee));
+
+            // Select Sapling notes
+            std::vector<SaplingOutPoint> ops;
+            std::vector<libzcash::SaplingNote> notes;
+            for (auto fromNote : fromNotes) {
+                ops.push_back(fromNote.op);
+                notes.push_back(fromNote.note);
+            }
+
+            // Fetch Sapling anchor and witnesses
+            uint256 anchor;
+            std::vector<boost::optional<SaplingWitness>> witnesses;
+            {
+                LOCK2(cs_main, pwalletMain->cs_wallet);
+                pwalletMain->GetSaplingNoteWitnesses(ops, witnesses, anchor);
+            }
+
+            // Add Sapling spends
+            for (size_t i = 0; i < notes.size(); i++) {
+                if (!witnesses[i]) {
+                    LogPrint("zrpcunsafe", "%s: Missing Witnesses. Stopping.\n", getId());
+                    break;
+                }
+                builder.AddSaplingSpend(extsk.expsk, notes[i], anchor, witnesses[i].get());
+            }
+
+            builder.SetFee(fConsolidationTxFee);
+            builder.AddSaplingOutput(extsk.expsk.ovk, addr, amountToSend - fConsolidationTxFee);
+            CTransaction tx = builder.Build().GetTxOrThrow();
+
+            if (isCancelled()) {
+                LogPrint("zrpcunsafe", "%s: Canceled. Stopping.\n", getId());
+                break;
+            }
+
+            pwalletMain->CommitConsolidationTx(tx);
+            LogPrint("zrpcunsafe", "%s: Committed consolidation transaction with txid=%s\n", getId(), tx.GetHash().ToString());
+            amountConsolidated += amountToSend - fConsolidationTxFee;
+            consolidationTxIds.push_back(tx.GetHash().ToString());
+
+        }
+    }
+
+    LogPrint("zrpcunsafe", "%s: Created %d transactions with total Sapling output amount=%s\n", getId(), numTxCreated, FormatMoney(amountConsolidated));
+    setConsolidationResult(numTxCreated, amountConsolidated, consolidationTxIds);
+    return true;
+
+}
+
+void AsyncRPCOperation_saplingconsolidation::setConsolidationResult(int numTxCreated, const CAmount& amountConsolidated, const std::vector<std::string>& consolidationTxIds) {
+    UniValue res(UniValue::VOBJ);
+    res.push_back(Pair("num_tx_created", numTxCreated));
+    res.push_back(Pair("amount_consolidated", FormatMoney(amountConsolidated)));
+    UniValue txIds(UniValue::VARR);
+    for (const std::string& txId : consolidationTxIds) {
+        txIds.push_back(txId);
+    }
+    res.push_back(Pair("consolidation_txids", txIds));
+    set_result(res);
+}
+
+void AsyncRPCOperation_saplingconsolidation::cancel() {
+    set_state(OperationStatus::CANCELLED);
+}
+
+UniValue AsyncRPCOperation_saplingconsolidation::getStatus() const {
+    UniValue v = AsyncRPCOperation::getStatus();
+    UniValue obj = v.get_obj();
+    obj.push_back(Pair("method", "saplingconsolidation"));
+    obj.push_back(Pair("target_height", targetHeight_));
+    return obj;
+}

--- a/src/wallet/asyncrpcoperation_saplingconsolidation.h
+++ b/src/wallet/asyncrpcoperation_saplingconsolidation.h
@@ -1,0 +1,36 @@
+#include "amount.h"
+#include "asyncrpcoperation.h"
+#include "univalue.h"
+#include "zcash/Address.hpp"
+#include "zcash/zip32.h"
+
+//Default fee used for consolidation transactions
+static const CAmount DEFAULT_CONSOLIDATION_FEE = 0;
+extern CAmount fConsolidationTxFee;
+
+class AsyncRPCOperation_saplingconsolidation : public AsyncRPCOperation
+{
+public:
+    AsyncRPCOperation_saplingconsolidation(int targetHeight);
+    virtual ~AsyncRPCOperation_saplingconsolidation();
+
+    // We don't want to be copied or moved around
+    AsyncRPCOperation_saplingconsolidation(AsyncRPCOperation_saplingconsolidation const&) = delete;            // Copy construct
+    AsyncRPCOperation_saplingconsolidation(AsyncRPCOperation_saplingconsolidation&&) = delete;                 // Move construct
+    AsyncRPCOperation_saplingconsolidation& operator=(AsyncRPCOperation_saplingconsolidation const&) = delete; // Copy assign
+    AsyncRPCOperation_saplingconsolidation& operator=(AsyncRPCOperation_saplingconsolidation&&) = delete;      // Move assign
+
+    virtual void main();
+
+    virtual void cancel();
+
+    virtual UniValue getStatus() const;
+
+private:
+    int targetHeight_;
+
+    bool main_impl();
+
+    void setConsolidationResult(int numTxCreated, const CAmount& amountConsolidated, const std::vector<std::string>& consolidationTxIds);
+
+};

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -89,7 +89,7 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
         nEnvFlags |= DB_PRIVATE;
 
     dbenv->set_lg_dir(pathLogDir.string().c_str());
-    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv->set_cachesize(1, 0x100000, 1); // 1 MiB should be enough for just the wallet, Increased by 1 GB
     dbenv->set_lg_bsize(0x10000);
     dbenv->set_lg_max(1048576);
     dbenv->set_lk_max_locks(40000);
@@ -163,6 +163,55 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, bool (*recoverFu
     // Try to recover:
     bool fRecovered = (*recoverFunc)(*this, strFile);
     return (fRecovered ? RECOVER_OK : RECOVER_FAIL);
+}
+
+bool CDBEnv::Compact(const std::string& strFile)
+{
+    LOCK(cs_db);
+
+    DB_COMPACT dbcompact;
+    dbcompact.compact_fillpercent = 100;
+    dbcompact.compact_pages = DB_MAX_PAGES;
+    dbcompact.compact_timeout = 0;
+
+    DB_COMPACT *pdbcompact;
+    pdbcompact = &dbcompact;
+
+    int result = 1;
+    if (mapDb[strFile] != NULL) {
+        Db* pdb = mapDb[strFile];
+        result = pdb->compact(NULL, NULL, NULL, pdbcompact, DB_FREE_SPACE, NULL);
+        delete pdb;
+        mapDb[strFile] = NULL;
+
+      switch (result)
+      {
+        case DB_LOCK_DEADLOCK:
+          LogPrint("db","Deadlock %i\n", result);
+          break;
+        case DB_LOCK_NOTGRANTED:
+          LogPrint("db","Lock Not Granted %i\n", result);
+          break;
+        case DB_REP_HANDLE_DEAD:
+          LogPrint("db","Handle Dead %i\n", result);
+          break;
+        case DB_REP_LOCKOUT:
+          LogPrint("db","Rep Lockout %i\n", result);
+          break;
+        case EACCES:
+          LogPrint("db","Eacces %i\n", result);
+          break;
+        case EINVAL:
+          LogPrint("db","Error Invalid %i\n", result);
+          break;
+        case 0:
+          LogPrint("db","Wallet Compact Sucessful\n");
+          break;
+        default:
+          LogPrint("db","Compact result int %i\n", result);
+      }
+    }
+    return (result == 0);
 }
 
 bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<CDBEnv::KeyValPair>& vResult)

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -63,6 +63,7 @@ public:
      * NOTE: reads the entire database into memory, so cannot be used
      * for huge databases.
      */
+    bool Compact(const std::string& strFile);
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(const std::string& strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -51,12 +51,12 @@ public:
         return CCryptoKeyStore::Unlock(vMasterKeyIn);
     }
 
-    void IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                const CBlock* pblock,
-                                SproutMerkleTree& sproutTree,
-                                SaplingMerkleTree& saplingTree) {
-        CWallet::IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
-    }
+    // void IncrementNoteWitnesses(const CBlockIndex* pindex,
+    //                             const CBlock* pblock,
+    //                             SproutMerkleTree& sproutTree,
+    //                             SaplingMerkleTree& saplingTree) {
+    //     CWallet::IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
+    // }
     void DecrementNoteWitnesses(const CBlockIndex* pindex) {
         CWallet::DecrementNoteWitnesses(pindex);
     }
@@ -118,7 +118,7 @@ std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
     wallet.AddToWallet(wtx, true, NULL);
 
     block.vtx.push_back(wtx);
-    wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
+    //wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
 
     return std::make_pair(jsoutpt, saplingNotes[0]);
 }
@@ -665,7 +665,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
+    // wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -917,7 +917,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     }
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
+    // wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -1027,7 +1027,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     // Simulate receiving new block and ChainTip signal.
     // This triggers calculation of nullifiers for notes belonging to this wallet
     // in the output descriptions of wtx.
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
+    // wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -1161,7 +1161,7 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
     CBlockIndex index(block);
     SproutMerkleTree sproutTree;
     SaplingMerkleTree saplingTree;
-    wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
+    // wallet.IncrementNoteWitnesses(&index, &block, sproutTree, saplingTree);
 
     ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1231,7 +1231,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         index2.nHeight = 2;
         SproutMerkleTree sproutTree2 {sproutTree};
         SaplingMerkleTree saplingTree2 {saplingTree};
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree2, saplingTree2);
+        // wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree2, saplingTree2);
 
         auto anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors2.first, anchors2.second);
@@ -1252,7 +1252,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_NE(anchors1.second, anchors3.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        // wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
         auto anchors4 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors4.first, anchors4.second);
 
@@ -1262,7 +1262,7 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         EXPECT_EQ(anchors2.second, anchors4.second);
 
         // Incrementing with the same block again should not change the cache
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        // wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
         std::vector<boost::optional<SproutWitness>> sproutWitnesses5;
         std::vector<boost::optional<SaplingWitness>> saplingWitnesses5;
 
@@ -1345,7 +1345,7 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
         EXPECT_NE(anchors2.second, anchors4.second);
 
         // Re-incrementing with the same block should give the same result
-        wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
+        // wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
 
         auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1402,7 +1402,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
     for (size_t i = 0; i < numBlocks; i++) {
         SproutMerkleTree sproutRiPrevTree {sproutRiTree};
         SaplingMerkleTree saplingRiPrevTree {saplingRiTree};
-        wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiTree, saplingRiTree);
+        // wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiTree, saplingRiTree);
 
         auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         for (size_t j = 0; j < numBlocks; j++) {
@@ -1429,7 +1429,7 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
             }
 
             {
-                wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiPrevTree, saplingRiPrevTree);
+                // wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), sproutRiPrevTree, saplingRiPrevTree);
                 auto anchors = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
                 for (size_t j = 0; j < numBlocks; j++) {
                     EXPECT_TRUE((bool) sproutWitnesses[j]);
@@ -1803,7 +1803,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
+    // wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, testNote.tree);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet
@@ -1948,7 +1948,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     wallet.AddToWallet(wtx, true, NULL);
 
     // Simulate receiving new block and ChainTip signal
-    wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
+    // wallet.IncrementNoteWitnesses(&fakeIndex, &block, sproutTree, saplingTree);
     wallet.UpdateSaplingNullifierNoteMapForBlock(&block);
 
     // Retrieve the updated wtx from wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -45,6 +45,10 @@ unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = true;
 bool fSendFreeTransactions = false;
 bool fPayAtLeastCustomFee = true;
+bool fTxDeleteEnabled = false;
+int fDeleteInterval = DEFAULT_TX_DELETE_INTERVAL;
+unsigned int fDeleteTransactionsAfterNBlocks = DEFAULT_TX_RETENTION_BLOCKS;
+unsigned int fKeepLastNTransactions = DEFAULT_TX_RETENTION_LASTTX;
 
 /**
  * Fees smaller than this (in satoshi) are considered zero fee (for transaction creation)
@@ -565,7 +569,8 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 void CWallet::ChainTipAdded(const CBlockIndex *pindex,
                             const CBlock *pblock,
                             SproutMerkleTree sproutTree,
-                            SaplingMerkleTree saplingTree)
+                            SaplingMerkleTree saplingTree,
+                            bool calculateWitnesses)
 {
     IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
     UpdateSaplingNullifierNoteMapForBlock(pblock);
@@ -578,7 +583,7 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
                        bool added)
 {
     if (added) {
-        ChainTipAdded(pindex, pblock, sproutTree, saplingTree);
+        ChainTipAdded(pindex, pblock, sproutTree, saplingTree, true);
         // Prevent migration transactions from being created when node is syncing after launch,
         // and also when node wakes up from suspension/hibernation and incoming blocks are old.
         if (!IsInitialBlockDownload(Params()) &&
@@ -590,6 +595,7 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
         DecrementNoteWitnesses(pindex);
         UpdateSaplingNullifierNoteMapForBlock(pblock);
     }
+    DeleteWalletTransactions(pindex, false);
 }
 
 void CWallet::RunSaplingMigration(int blockHeight) {
@@ -926,6 +932,22 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
     return false;
 }
 
+unsigned int CWallet::GetSpendDepth(const uint256& hash, unsigned int n) const
+{
+    const COutPoint outpoint(hash, n);
+    pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
+    range = mapTxSpends.equal_range(outpoint);
+
+    for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
+            return mit->second.GetDepthInMainChain(); // Spent
+    }
+    return 0;
+}
+
 /**
  * Note is spent if any non-conflicted transaction
  * spends it:
@@ -956,6 +978,20 @@ bool CWallet::IsSaplingSpent(const uint256& nullifier) const {
         }
     }
     return false;
+}
+
+unsigned int CWallet::GetSaplingSpendDepth(const uint256& nullifier) const {
+    pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+
+    for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0) {
+            return mit->second.GetDepthInMainChain(); // Spent
+        }
+    }
+    return 0;
 }
 
 void CWallet::AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid)
@@ -2476,6 +2512,120 @@ void CWallet::WitnessNoteCommitment(std::vector<uint256> commitments,
         }
     }
 }
+/**
+ * Delete transactions from the Wallet
+ */
+
+void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex, bool runImmediately) {
+
+      LOCK2(cs_wallet,cs_main);
+
+      int nDeleteAfter = (int)fDeleteTransactionsAfterNBlocks;
+
+      if (pindex && fTxDeleteEnabled
+        && ((pindex->nHeight % fDeleteInterval == 0 && IsInitialBlockDownload(Params()))
+         || !IsInitialBlockDownload(Params()) || runImmediately)) {
+
+        //Every note needs at least 1 witness to calculate the nullifers to determine spent status.
+        BuildWitnessCache(pindex, true);
+
+        for (int d = 0; d < 2; d++){
+
+          int txCount = 0;
+          int txSaveCount = 0;
+          std::vector<uint256> removeTxs;
+          std::map<int64_t, CWalletTx*> mapSorted;
+
+          // Sort pending wallet transactions based on their initial wallet insertion order
+          BOOST_FOREACH(PAIRTYPE(const uint256, CWalletTx)& item, mapWallet)
+          {
+              CWalletTx& wtx = item.second;
+              mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+          }
+
+          BOOST_FOREACH(PAIRTYPE(const int64_t, CWalletTx*)& item, mapSorted)
+          {
+
+            CWalletTx& wtx = *(item.second);
+            const uint256& wtxid = wtx.GetHash();
+            bool deleteTx = true;
+            txCount += 1;
+
+            //Keep anything newer than N Blocks
+            if (wtx.GetDepthInMainChain() < nDeleteAfter && wtx.GetDepthInMainChain() >= 0) {
+              deleteTx = false;
+            } else if (wtx.GetDepthInMainChain() < 0) {
+              deleteTx = true;
+            } else {
+
+              //Check for unspent inputs or spend less than N Blocks ago. (Sapling)
+              for (auto & pair : wtx.mapSaplingNoteData) {
+                SaplingNoteData nd = pair.second;
+                if (!nd.nullifier || pwalletMain->GetSaplingSpendDepth(*nd.nullifier) <= fDeleteTransactionsAfterNBlocks) {
+                  deleteTx = false;
+                }
+              }
+
+              //Chcek for output with that no longer have parents in the wallet. (Sapling)
+              for (int i = 0; i < wtx.vShieldedSpend.size(); i++) {
+                const SpendDescription& spendDesc = wtx.vShieldedSpend[i];
+                if (pwalletMain->IsSaplingNullifierFromMe(spendDesc.nullifier)) {
+                  const CWalletTx* parent = pwalletMain->GetWalletTx(pwalletMain->mapSaplingNullifiersToNotes[spendDesc.nullifier].hash);
+                  if (parent != NULL) {
+                    deleteTx = false;
+                  }
+                }
+              }
+
+              //Check for unspent inputs or spend less than N Blocks ago. (Transparent)
+              for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+                CTxDestination address;
+                ExtractDestination(wtx.vout[i].scriptPubKey, address);
+                if(IsMine(wtx.vout[i])) {
+                  if (pwalletMain->GetSpendDepth(wtx.GetHash(), i) <= fDeleteTransactionsAfterNBlocks) {
+                    deleteTx = false;
+                  }
+                }
+              }
+
+              //Chcek for output with that no longer have parents in the wallet. (Transparent)
+              for (int i = 0; i < wtx.vin.size(); i++) {
+                const CTxIn& txin = wtx.vin[i];
+                const CWalletTx* parent = pwalletMain->GetWalletTx(txin.prevout.hash);
+                if (parent != NULL) {
+                  deleteTx = false;
+                }
+              }
+            }
+
+            //Keep unconfirmed and conflicts during intial download.
+            if (wtx.GetDepthInMainChain() <= 0 && IsInitialBlockDownload(Params()))
+              deleteTx = true;
+
+            //Keep Last N Transactions
+            if (mapSorted.size() - txCount <= fKeepLastNTransactions)
+              deleteTx = false;
+
+            //Collect everything else for deletion
+            if (deleteTx) {
+              removeTxs.push_back(wtxid);
+            } else {
+              txSaveCount += 1;
+            }
+          }
+
+          //Delete Transactions from wallet
+          for (int i = 0; i < int(removeTxs.size()); i++) {
+            EraseFromWallet(removeTxs[i]);
+          }
+
+          //Compress Wallet
+          LogPrint("db","Total Transaction Count %i, Transactions Deleted %i, ", txCount, txCount-txSaveCount);
+          CWalletDB::Compact(bitdb,strWalletFile);
+        }
+      }
+}
+
 
 /**
  * Scan the block chain (starting in pindexStart) for transactions
@@ -2529,7 +2679,11 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
                 }
             }
             // Increment note witness caches
-            ChainTipAdded(pindex, &block, sproutTree, saplingTree);
+            if (pindex->nHeight == chainActive.Tip()->nHeight) {
+              ChainTipAdded(pindex, &block, sproutTree, saplingTree, true);
+            } else {
+              ChainTipAdded(pindex, &block, sproutTree, saplingTree, false);
+            }
 
             pindex = chainActive.Next(pindex);
             if (GetTime() >= nNow + 60) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -25,6 +25,7 @@
 #include "zcash/Note.hpp"
 #include "crypter.h"
 #include "wallet/asyncrpcoperation_saplingmigration.h"
+#include "wallet/asyncrpcoperation_saplingconsolidation.h"
 #include "zcash/zip32.h"
 
 #include <assert.h>
@@ -592,6 +593,7 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
             pblock->GetBlockTime() > GetAdjustedTime() - 3 * 60 * 60)
         {
             RunSaplingMigration(pindex->nHeight);
+            RunSaplingConsolidation(pindex->nHeight);
         }
     } else {
         DecrementNoteWitnesses(pindex);
@@ -642,6 +644,34 @@ void CWallet::RunSaplingMigration(int blockHeight) {
 void CWallet::AddPendingSaplingMigrationTx(const CTransaction& tx) {
     LOCK(cs_wallet);
     pendingSaplingMigrationTxs.push_back(tx);
+}
+
+void CWallet::RunSaplingConsolidation(int blockHeight) {
+    if (!Params().GetConsensus().NetworkUpgradeActive(blockHeight, Consensus::UPGRADE_SAPLING)) {
+        return;
+    }
+    LOCK(cs_wallet);
+    if (!fSaplingConsolidationEnabled) {
+        return;
+    }
+
+    int consolidateInterval = rand() % 5 + 5;
+    if (blockHeight % consolidateInterval == 0) {
+        std::shared_ptr<AsyncRPCQueue> q = getAsyncRPCQueue();
+        std::shared_ptr<AsyncRPCOperation> lastOperation = q->getOperationForId(saplingConsolidationOperationId);
+        if (lastOperation != nullptr) {
+            lastOperation->cancel();
+        }
+        pendingSaplingConsolidationTxs.clear();
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_saplingconsolidation(blockHeight + 5));
+        saplingConsolidationOperationId = operation->getId();
+        q->addOperation(operation);
+    }
+}
+
+void CWallet::CommitConsolidationTx(const CTransaction& tx) {
+  CWalletTx wtx(this, tx);
+  CommitTransaction(wtx, boost::none);
 }
 
 void CWallet::SetBestChain(const CBlockLocator& loc)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -572,8 +572,10 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
                             SaplingMerkleTree saplingTree,
                             bool calculateWitnesses)
 {
-    IncrementNoteWitnesses(pindex, pblock, sproutTree, saplingTree);
-    UpdateSaplingNullifierNoteMapForBlock(pblock);
+    if (!IsInitialBlockDownload(Params()) && calculateWitnesses) {
+      BuildWitnessCache(pindex, false);
+      UpdateSaplingNullifierNoteMapForBlock(pblock);
+    }
 }
 
 void CWallet::ChainTip(const CBlockIndex *pindex,
@@ -1054,222 +1056,224 @@ void CWallet::ClearNoteWitnessCache()
             item.second.witnessHeight = -1;
         }
     }
-    nWitnessCacheSize = 0;
-}
-
-template<typename NoteDataMap>
-void CopyPreviousWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        // Only increment witnesses that are behind the current height
-        if (nd->witnessHeight < indexHeight) {
-            // Check the validity of the cache
-            // The only time a note witnessed above the current height
-            // would be invalid here is during a reindex when blocks
-            // have been decremented, and we are incrementing the blocks
-            // immediately after.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            // Witnesses being incremented should always be either -1
-            // (never incremented or decremented) or one below indexHeight
-            assert((nd->witnessHeight == -1) || (nd->witnessHeight == indexHeight - 1));
-            // Copy the witness for the previous block if we have one
-            if (nd->witnesses.size() > 0) {
-                nd->witnesses.push_front(nd->witnesses.front());
-            }
-            if (nd->witnesses.size() > WITNESS_CACHE_SIZE) {
-                nd->witnesses.pop_back();
-            }
-        }
-    }
-}
-
-template<typename NoteDataMap>
-void AppendNoteCommitment(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const uint256& note_commitment)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        if (nd->witnessHeight < indexHeight && nd->witnesses.size() > 0) {
-            // Check the validity of the cache
-            // See comment in CopyPreviousWitnesses about validity.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            nd->witnesses.front().append(note_commitment);
-        }
-    }
-}
-
-template<typename OutPoint, typename NoteData, typename Witness>
-void WitnessNoteIfMine(std::map<OutPoint, NoteData>& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const OutPoint& key, const Witness& witness)
-{
-    if (noteDataMap.count(key) && noteDataMap[key].witnessHeight < indexHeight) {
-        auto* nd = &(noteDataMap[key]);
-        if (nd->witnesses.size() > 0) {
-            // We think this can happen because we write out the
-            // witness cache state after every block increment or
-            // decrement, but the block index itself is written in
-            // batches. So if the node crashes in between these two
-            // operations, it is possible for IncrementNoteWitnesses
-            // to be called again on previously-cached blocks. This
-            // doesn't affect existing cached notes because of the
-            // NoteData::witnessHeight checks. See #1378 for details.
-            LogPrintf("Inconsistent witness cache state found for %s\n- Cache size: %d\n- Top (height %d): %s\n- New (height %d): %s\n",
-                        key.ToString(), nd->witnesses.size(),
-                        nd->witnessHeight,
-                        nd->witnesses.front().root().GetHex(),
-                        indexHeight,
-                        witness.root().GetHex());
-            nd->witnesses.clear();
-        }
-        nd->witnesses.push_front(witness);
-        // Set height to one less than pindex so it gets incremented
-        nd->witnessHeight = indexHeight - 1;
-        // Check the validity of the cache
-        assert(nWitnessCacheSize >= nd->witnesses.size());
-    }
-}
-
-
-template<typename NoteDataMap>
-void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        if (nd->witnessHeight < indexHeight) {
-            nd->witnessHeight = indexHeight;
-            // Check the validity of the cache
-            // See comment in CopyPreviousWitnesses about validity.
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-        }
-    }
-}
-
-void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                     const CBlock* pblockIn,
-                                     SproutMerkleTree& sproutTree,
-                                     SaplingMerkleTree& saplingTree)
-{
-    LOCK(cs_wallet);
-    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-       ::CopyPreviousWitnesses(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-       ::CopyPreviousWitnesses(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
-    }
-
-    if (nWitnessCacheSize < WITNESS_CACHE_SIZE) {
-        nWitnessCacheSize += 1;
-    }
-
-    const CBlock* pblock {pblockIn};
-    CBlock block;
-    if (!pblock) {
-        ReadBlockFromDisk(block, pindex, Params().GetConsensus());
-        pblock = &block;
-    }
-
-    for (const CTransaction& tx : pblock->vtx) {
-        auto hash = tx.GetHash();
-        bool txIsOurs = mapWallet.count(hash);
-        // Sprout
-        for (size_t i = 0; i < tx.vJoinSplit.size(); i++) {
-            const JSDescription& jsdesc = tx.vJoinSplit[i];
-            for (uint8_t j = 0; j < jsdesc.commitments.size(); j++) {
-                const uint256& note_commitment = jsdesc.commitments[j];
-                sproutTree.append(note_commitment);
-
-                // Increment existing witnesses
-                for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-                    ::AppendNoteCommitment(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize, note_commitment);
-                }
-
-                // If this is our note, witness it
-                if (txIsOurs) {
-                    JSOutPoint jsoutpt {hash, i, j};
-                    ::WitnessNoteIfMine(mapWallet[hash].mapSproutNoteData, pindex->nHeight, nWitnessCacheSize, jsoutpt, sproutTree.witness());
-                }
-            }
-        }
-        // Sapling
-        for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
-            const uint256& note_commitment = tx.vShieldedOutput[i].cm;
-            saplingTree.append(note_commitment);
-
-            // Increment existing witnesses
-            for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-                ::AppendNoteCommitment(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize, note_commitment);
-            }
-
-            // If this is our note, witness it
-            if (txIsOurs) {
-                SaplingOutPoint outPoint {hash, i};
-                ::WitnessNoteIfMine(mapWallet[hash].mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize, outPoint, saplingTree.witness());
-            }
-        }
-    }
-
-    // Update witness heights
-    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-        ::UpdateWitnessHeights(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-        ::UpdateWitnessHeights(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
-    }
-
-    // For performance reasons, we write out the witness cache in
-    // CWallet::SetBestChain() (which also ensures that overall consistency
-    // of the wallet.dat is maintained).
-}
-
-template<typename NoteDataMap>
-void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
-{
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        // Only decrement witnesses that are not above the current height
-        if (nd->witnessHeight <= indexHeight) {
-            // Check the validity of the cache
-            // See comment below (this would be invalid if there were a
-            // prior decrement).
-            assert(nWitnessCacheSize >= nd->witnesses.size());
-            // Witnesses being decremented should always be either -1
-            // (never incremented or decremented) or equal to the height
-            // of the block being removed (indexHeight)
-            assert((nd->witnessHeight == -1) || (nd->witnessHeight == indexHeight));
-            if (nd->witnesses.size() > 0) {
-                nd->witnesses.pop_front();
-            }
-            // indexHeight is the height of the block being removed, so
-            // the new witness cache height is one below it.
-            nd->witnessHeight = indexHeight - 1;
-        }
-        // Check the validity of the cache
-        // Technically if there are notes witnessed above the current
-        // height, their cache will now be invalid (relative to the new
-        // value of nWitnessCacheSize). However, this would only occur
-        // during a reindex, and by the time the reindex reaches the tip
-        // of the chain again, the existing witness caches will be valid
-        // again.
-        // We don't set nWitnessCacheSize to zero at the start of the
-        // reindex because the on-disk blocks had already resulted in a
-        // chain that didn't trigger the assertion below.
-        if (nd->witnessHeight < indexHeight) {
-            // Subtract 1 to compare to what nWitnessCacheSize will be after
-            // decrementing.
-            assert((nWitnessCacheSize - 1) >= nd->witnesses.size());
-        }
-    }
 }
 
 void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex)
 {
     LOCK(cs_wallet);
     for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
-        ::DecrementNoteWitnesses(wtxItem.second.mapSproutNoteData, pindex->nHeight, nWitnessCacheSize);
-        ::DecrementNoteWitnesses(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
-    }
-    nWitnessCacheSize -= 1;
-    // TODO: If nWitnessCache is zero, we need to regenerate the caches (#1302)
-    assert(nWitnessCacheSize > 0);
+      for (auto& item : wtxItem.second.mapSaplingNoteData) {
+        auto* nd = &(item.second);
 
-    // For performance reasons, we write out the witness cache in
-    // CWallet::SetBestChain() (which also ensures that overall consistency
-    // of the wallet.dat is maintained).
+        if (nd->nullifier && pwalletMain->GetSaplingSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+          // Only decrement witnesses that are not above the current height
+          if (nd->witnessHeight <= pindex->nHeight) {
+            if (nd->witnesses.size() > 1) {
+              // indexHeight is the height of the block being removed, so
+              // the new witness cache height is one below it.
+                nd->witnesses.pop_front();
+                nd->witnessHeight = pindex->nHeight - 1;
+            }
+          }
+        }
+      }
+    }
+}
+
+void CWallet::ClearSingleNoteWitnessCache(SaplingNoteData* nd)
+{
+  nd->witnesses.clear();
+  nd->witnessHeight = -1;
+}
+
+int CWallet::WitnessMinimumHeight(const uint256& nullifier, int nWitnessHeight, int nMinimumHeight)
+{
+    if (GetSaplingSpendDepth(nullifier) <= WITNESS_CACHE_SIZE) {
+      nMinimumHeight = min(nWitnessHeight, nMinimumHeight);
+    }
+    return nMinimumHeight;
+}
+
+int CWallet::VerifyAndSetInitialWitness(const CBlockIndex* pindex)
+{
+  LOCK2(cs_wallet,cs_main);
+
+  int nWitnessTxIncrement = 0;
+  int nWitnessTotalTxCount = mapWallet.size();
+  int nMinimumHeight = pindex->nHeight;
+
+  for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+    bool changed = false;
+    nWitnessTxIncrement += 1;
+
+    for (mapSaplingNoteData_t::value_type& item : wtxItem.second.mapSaplingNoteData) {
+      if (wtxItem.second.GetDepthInMainChain() > 0) {
+        auto op = item.first;
+        auto* nd = &(item.second);
+        auto wtxHash = wtxItem.second.GetHash();
+        CBlockIndex* pblockindex;
+        uint256 blockRoot;
+        uint256 witnessRoot;
+
+        if (!nd->nullifier)
+          ClearSingleNoteWitnessCache(nd);
+
+        if (!nd->witnesses.empty() && nd->witnessHeight > 0) {
+
+          //Skip Validation when witness height is greater that block height
+          if (nd->witnessHeight > pindex->nHeight - 1) {
+            nMinimumHeight = WitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Validate current block if witness is from the previous block
+          blockRoot = pindex->pprev->hashFinalSaplingRoot;
+          witnessRoot = nd->witnesses.front().root();
+          if (nd->witnessHeight == pindex->nHeight - 1 && witnessRoot == blockRoot) {
+            nMinimumHeight = WitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+
+          //Validate the witness at the witness height
+          pblockindex = chainActive[nd->witnessHeight];
+          blockRoot = pblockindex->hashFinalSaplingRoot;
+          if (witnessRoot == blockRoot) {
+            nMinimumHeight = WitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+            continue;
+          }
+        }
+
+        //Clear witness Cache for all other scenarios
+        ClearSingleNoteWitnessCache(nd);
+        changed = true;
+
+        //Get the block index of note
+        CTransaction ctx;
+        uint256 hashBlock;
+        GetTransaction(wtxHash, ctx, Params().GetConsensus(), hashBlock, true);
+
+        BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
+        if (mi != mapBlockIndex.end() && (*mi).second) {
+          CBlockIndex* pfoundindex = (*mi).second;
+          if (chainActive.Contains(pfoundindex)) {
+              pblockindex = chainActive[pfoundindex->nHeight];
+          }
+        }
+
+
+        SaplingMerkleTree saplingTree;
+        blockRoot = pblockindex->pprev->hashFinalSaplingRoot;
+        pcoinsTip->GetSaplingAnchorAt(blockRoot, saplingTree);
+
+        //Cycle through blocks and transactions build sapling tree until the commitment needed is reached
+        const CBlock* pblock;
+        CBlock block;
+        ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
+        pblock = &block;
+
+        for (const CTransaction& tx : block.vtx) {
+          auto hash = tx.GetHash();
+
+          // Sapling
+          for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
+            const uint256& note_commitment = tx.vShieldedOutput[i].cm;
+
+            // Increment existing witness until the end of the block
+            if (!nd->witnesses.empty()) {
+              nd->witnesses.front().append(note_commitment);
+            }
+
+            //Only needed for intial witness
+            if (nd->witnesses.empty()) {
+              saplingTree.append(note_commitment);
+
+              // If this is our note, witness it
+              if (hash == wtxHash) {
+                SaplingOutPoint outPoint {hash, i};
+                if (op == outPoint) {
+                  nd->witnesses.push_front(saplingTree.witness());
+                  UpdateSaplingNullifierNoteMapForBlock(pblock);
+                }
+              }
+            }
+          }
+        }
+
+        nd->witnessHeight = pblockindex->nHeight;
+        nMinimumHeight = WitnessMinimumHeight(*item.second.nullifier, nd->witnessHeight, nMinimumHeight);
+      }
+    }
+
+    // if (changed) {
+    //   CWalletDB walletdb(strWalletFile, "r+", false);
+    //   wtxItem.second.WriteToDisk(&walletdb);
+    // }
+  }
+
+  return nMinimumHeight;
+}
+
+void CWallet::BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly)
+{
+
+  int startHeight = VerifyAndSetInitialWitness(pindex) + 1;
+
+  LOCK2(cs_wallet,cs_main);
+
+  if (startHeight > pindex->nHeight || witnessOnly) {
+    return;
+  }
+
+  uint256 blockRoot;
+  CBlockIndex* pblockindex = chainActive[startHeight];
+
+  while (pblockindex) {
+
+    if (pblockindex->nHeight % 100 == 0 && pblockindex->nHeight < chainActive.Height() - 5) {
+      double height = chainActive.Height();
+      LogPrintf("Building Witness for block %i %.4f complete\n", pblockindex->nHeight, pblockindex->nHeight / height);
+    }
+
+    SaplingMerkleTree saplingTree;
+    blockRoot = pblockindex->pprev->hashFinalSaplingRoot;
+    pcoinsTip->GetSaplingAnchorAt(blockRoot, saplingTree);
+
+    //Cycle through blocks and transactions building sapling tree until the commitment needed is reached
+    CBlock block;
+    ReadBlockFromDisk(block, pblockindex, Params().GetConsensus());
+
+    for (std::pair<const uint256, CWalletTx>& wtxItem : mapWallet) {
+      if (wtxItem.second.GetDepthInMainChain() > 0) {
+        for (mapSaplingNoteData_t::value_type& item : wtxItem.second.mapSaplingNoteData) {
+          auto* nd = &(item.second);
+          if (nd->nullifier && nd->witnessHeight == pblockindex->nHeight - 1
+              && GetSaplingSpendDepth(*item.second.nullifier) <= WITNESS_CACHE_SIZE) {
+
+
+            nd->witnesses.push_front(nd->witnesses.front());
+            if (nd->witnesses.size() > WITNESS_CACHE_SIZE) {
+                nd->witnesses.pop_back();
+            }
+
+            for (const CTransaction& tx : block.vtx) {
+              // Sapling
+              for (uint32_t i = 0; i < tx.vShieldedOutput.size(); i++) {
+                const uint256& note_commitment = tx.vShieldedOutput[i].cm;
+                nd->witnesses.front().append(note_commitment);
+              }
+            }
+            nd->witnessHeight = pblockindex->nHeight;
+          }
+        }
+      }
+    }
+
+    if (pblockindex == pindex)
+      break;
+
+    pblockindex = chainActive.Next(pblockindex);
+
+  }
 }
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -791,13 +791,19 @@ public:
     void ClearNoteWitnessCache();
 
 protected:
+
+    void ClearSingleNoteWitnessCache(SaplingNoteData* nd);
+    int WitnessMinimumHeight(const uint256& nullifier, int nWitnessHeight, int nMinimumHeight);
+    int VerifyAndSetInitialWitness(const CBlockIndex* pindex);
+    void BuildWitnessCache(const CBlockIndex* pindex, bool witnessOnly);
+
     /**
      * pindex is the new tip being connected.
      */
-    void IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                const CBlock* pblock,
-                                SproutMerkleTree& sproutTree,
-                                SaplingMerkleTree& saplingTree);
+    // void IncrementNoteWitnesses(const CBlockIndex* pindex,
+    //                             const CBlock* pblock,
+    //                             SproutMerkleTree& sproutTree,
+    //                             SaplingMerkleTree& saplingTree);
     /**
      * pindex is the old tip being disconnected.
      */
@@ -852,7 +858,7 @@ protected:
 private:
     template <class T>
     void SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename TxSpendMap<T>::iterator>);
-    void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree);
+    void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool calculateWitnesses);
 
 protected:
     bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -47,6 +47,11 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
 extern bool fPayAtLeastCustomFee;
+extern bool fTxDeleteEnabled;
+extern int fDeleteInterval;
+extern unsigned int fDeleteTransactionsAfterNBlocks;
+extern unsigned int fKeepLastNTransactions;
+
 
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
@@ -67,6 +72,15 @@ static const unsigned int WITNESS_CACHE_SIZE = MAX_REORG_LENGTH + 1;
 
 //! Size of HD seed in bytes
 static const size_t HD_WALLET_SEED_LENGTH = 32;
+
+//Default Transaction Rentention N-BLOCKS
+static const int DEFAULT_TX_DELETE_INTERVAL = 1000;
+
+//Default Transaction Rentention N-BLOCKS
+static const unsigned int DEFAULT_TX_RETENTION_BLOCKS = 1000;
+
+//Default Retenion Last N-Transactions
+static const unsigned int DEFAULT_TX_RETENTION_LASTTX = 200;
 
 class CBlockIndex;
 class CCoinControl;
@@ -979,8 +993,10 @@ public:
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
+    unsigned int GetSpendDepth(const uint256& hash, unsigned int n) const;
     bool IsSproutSpent(const uint256& nullifier) const;
     bool IsSaplingSpent(const uint256& nullifier) const;
+    unsigned int GetSaplingSpendDepth(const uint256& nullifier) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
@@ -1125,6 +1141,7 @@ public:
          std::vector<uint256> commitments,
          std::vector<boost::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
+    void DeleteWalletTransactions(const CBlockIndex* pindex, bool runImmediately);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -774,6 +774,9 @@ private:
     std::vector<CTransaction> pendingSaplingMigrationTxs;
     AsyncRPCOperationId saplingMigrationOperationId;
 
+    std::vector<CTransaction> pendingSaplingConsolidationTxs;
+    AsyncRPCOperationId saplingConsolidationOperationId;
+
     void AddToTransparentSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSproutSpends(const uint256& nullifier, const uint256& wtxid);
     void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
@@ -787,6 +790,7 @@ public:
      */
     int64_t nWitnessCacheSize;
     bool fSaplingMigrationEnabled = false;
+    bool fSaplingConsolidationEnabled = false;
 
     void ClearNoteWitnessCache();
 
@@ -1215,6 +1219,8 @@ public:
     void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SproutMerkleTree sproutTree, SaplingMerkleTree saplingTree, bool added);
     void RunSaplingMigration(int blockHeight);
     void AddPendingSaplingMigrationTx(const CTransaction& tx);
+    void RunSaplingConsolidation(int blockHeight);
+    void CommitConsolidationTx(const CTransaction& tx);
     /** Saves witness caches and best block locator to disk. */
     void SetBestChain(const CBlockLocator& loc);
     std::set<std::pair<libzcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzcash::PaymentAddress> & addresses);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1161,6 +1161,11 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
     return false;
 }
 
+bool CWalletDB::Compact(CDBEnv& dbenv, const std::string& strFile)
+{
+  bool fSuccess = dbenv.Compact(strFile);
+  return fSuccess;
+}
 //
 // Try to (very carefully!) recover wallet.dat if there is a problem.
 //

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -174,6 +174,7 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTxToZap(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
+    static bool Compact(CDBEnv& dbenv, const std::string& strFile);
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 


### PR DESCRIPTION
This pull request does several things.

1. Creates a new method to compact the wallet.dat file when data is removed
2. Delete old transactions
    a. Spent Note, Spent TXO's
    b. Outgoing transactions after inputs no longer exist
    c. sets minimum number of block to retain
    d. sets the last N transactions to retain

3. Sapling Note witness rework.
    a. Witnesses are not created until the blockchain has finished it;s intial sync
    b. Initial Witnesses are created during the Delete Tx processes during inital sync or at the time of block processing after inital sync.
    c. Witnesses are validated against the sapling root of the block corresponding to the witness height, witnesses are recalculated if the validation fails.

4. Automatic Note consolidation. 
   a. When enabled the note will automatically create consolidation transaction at between  a random 5 - 10 block intervals with between a random minimum of 2 - 12 inputs and a random maximum 10 - 45 inputs. 
   b. Consolidation Tx fee can be set in the .conf file with a satoshi value, default 0. 
    
