### PR TITLE
Set minimum fDeleteTransactionsAfterNBlocks to MAX_REORG_LENGTH + 1

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1744,6 +1744,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if (fDeleteTransactionsAfterNBlocks < 1)
           return InitError("keeptxfornblocks must be greater than 0");
 
+        if (fDeleteTransactionsAfterNBlocks < MAX_REORG_LENGTH + 1 ) {
+          LogPrintf("keeptxfornblock is less the MAX_REORG_LENGTH, Setting to %i\n", MAX_REORG_LENGTH + 1);
+          fDeleteTransactionsAfterNBlocks = MAX_REORG_LENGTH + 1;
+        }
 
         if (fFirstRun)
         {


### PR DESCRIPTION
set fDeleteTransactionAterNBlock to MAX_REORG_LENGTH + 1 as the minimum value allowed to prevent issues arising from chain reorg. 
